### PR TITLE
feat: add database schema migrations

### DIFF
--- a/migrations/000001_init_schema.down.sql
+++ b/migrations/000001_init_schema.down.sql
@@ -1,0 +1,23 @@
+-- Rollback Messaging Service Schema
+
+DROP TRIGGER IF EXISTS update_last_message_trigger ON messages;
+DROP TRIGGER IF EXISTS update_conversations_updated_at ON conversations;
+
+DROP FUNCTION IF EXISTS create_messages_partition(DATE);
+DROP FUNCTION IF EXISTS update_conversation_last_message();
+DROP FUNCTION IF EXISTS update_updated_at_column();
+
+DROP TABLE IF EXISTS pinned_messages;
+DROP TABLE IF EXISTS read_receipts;
+DROP TABLE IF EXISTS message_reactions;
+DROP TABLE IF EXISTS attachments;
+DROP TABLE IF EXISTS messages_y2026m02;
+DROP TABLE IF EXISTS messages_y2026m03;
+DROP TABLE IF EXISTS messages_y2026m04;
+DROP TABLE IF EXISTS messages_default;
+DROP TABLE IF EXISTS messages;
+DROP TABLE IF EXISTS conversation_participants;
+DROP TABLE IF EXISTS conversations;
+
+DROP TYPE IF EXISTS message_type;
+DROP TYPE IF EXISTS conversation_type;

--- a/migrations/000001_init_schema.up.sql
+++ b/migrations/000001_init_schema.up.sql
@@ -1,0 +1,200 @@
+-- Messaging Service Schema
+-- Handles conversations, messages, and real-time communication
+-- Optimized for high throughput (500K messages/second target)
+
+-- Enable required extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Conversation types
+CREATE TYPE conversation_type AS ENUM ('direct', 'group', 'channel');
+
+-- Message types
+CREATE TYPE message_type AS ENUM ('text', 'image', 'file', 'audio', 'video', 'system');
+
+-- Conversations table
+CREATE TABLE conversations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    type conversation_type NOT NULL DEFAULT 'direct',
+    name VARCHAR(100), -- NULL for direct messages
+    description TEXT,
+    avatar_url VARCHAR(500),
+    creator_id UUID, -- NULL for direct messages
+    is_archived BOOLEAN DEFAULT FALSE,
+    last_message_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Conversation participants
+CREATE TABLE conversation_participants (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL,
+    role VARCHAR(20) DEFAULT 'member', -- 'owner', 'admin', 'member'
+    nickname VARCHAR(100),
+    is_muted BOOLEAN DEFAULT FALSE,
+    muted_until TIMESTAMP WITH TIME ZONE,
+    last_read_at TIMESTAMP WITH TIME ZONE,
+    last_read_message_id UUID,
+    joined_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    left_at TIMESTAMP WITH TIME ZONE,
+
+    CONSTRAINT unique_participant UNIQUE (conversation_id, user_id)
+);
+
+-- Messages table (partitioned by month for performance)
+CREATE TABLE messages (
+    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    conversation_id UUID NOT NULL,
+    sender_id UUID NOT NULL,
+    type message_type DEFAULT 'text',
+    content TEXT,
+    metadata JSONB, -- For attachments, mentions, etc.
+    reply_to_id UUID, -- For threaded replies
+    is_edited BOOLEAN DEFAULT FALSE,
+    edited_at TIMESTAMP WITH TIME ZONE,
+    is_deleted BOOLEAN DEFAULT FALSE,
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+-- Create partitions for current and next months
+CREATE TABLE messages_y2026m02 PARTITION OF messages
+    FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+
+CREATE TABLE messages_y2026m03 PARTITION OF messages
+    FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
+
+CREATE TABLE messages_y2026m04 PARTITION OF messages
+    FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
+
+CREATE TABLE messages_default PARTITION OF messages DEFAULT;
+
+-- Message attachments
+CREATE TABLE attachments (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    message_id UUID NOT NULL,
+    message_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    file_type VARCHAR(100) NOT NULL,
+    file_size BIGINT NOT NULL,
+    file_url VARCHAR(500) NOT NULL,
+    thumbnail_url VARCHAR(500),
+    width INTEGER,
+    height INTEGER,
+    duration INTEGER, -- For audio/video in seconds
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    FOREIGN KEY (message_id, message_created_at) REFERENCES messages(id, created_at) ON DELETE CASCADE
+);
+
+-- Message reactions
+CREATE TABLE message_reactions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    message_id UUID NOT NULL,
+    message_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    user_id UUID NOT NULL,
+    emoji VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT unique_reaction UNIQUE (message_id, user_id, emoji),
+    FOREIGN KEY (message_id, message_created_at) REFERENCES messages(id, created_at) ON DELETE CASCADE
+);
+
+-- Read receipts (for direct messages and small groups)
+CREATE TABLE read_receipts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL,
+    last_read_message_id UUID NOT NULL,
+    last_read_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT unique_read_receipt UNIQUE (conversation_id, user_id)
+);
+
+-- Typing indicators (stored in Redis, but schema for reference)
+-- This is handled in Redis for real-time performance
+
+-- Pinned messages
+CREATE TABLE pinned_messages (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    message_id UUID NOT NULL,
+    message_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    pinned_by UUID NOT NULL,
+    pinned_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT unique_pin UNIQUE (conversation_id, message_id),
+    FOREIGN KEY (message_id, message_created_at) REFERENCES messages(id, created_at) ON DELETE CASCADE
+);
+
+-- Indexes for high-performance queries
+CREATE INDEX idx_conversations_last_message ON conversations(last_message_at DESC NULLS LAST);
+CREATE INDEX idx_conversations_type ON conversations(type);
+
+CREATE INDEX idx_participants_conversation ON conversation_participants(conversation_id);
+CREATE INDEX idx_participants_user ON conversation_participants(user_id) WHERE left_at IS NULL;
+CREATE INDEX idx_participants_user_conversations ON conversation_participants(user_id, conversation_id) WHERE left_at IS NULL;
+
+-- Partitioned indexes for messages (created on each partition)
+CREATE INDEX idx_messages_conversation ON messages(conversation_id, created_at DESC);
+CREATE INDEX idx_messages_sender ON messages(sender_id, created_at DESC);
+CREATE INDEX idx_messages_reply ON messages(reply_to_id) WHERE reply_to_id IS NOT NULL;
+
+CREATE INDEX idx_attachments_message ON attachments(message_id);
+CREATE INDEX idx_reactions_message ON message_reactions(message_id);
+CREATE INDEX idx_read_receipts_conversation ON read_receipts(conversation_id);
+CREATE INDEX idx_pinned_messages_conversation ON pinned_messages(conversation_id);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_conversations_updated_at
+    BEFORE UPDATE ON conversations
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Function to update conversation last_message_at
+CREATE OR REPLACE FUNCTION update_conversation_last_message()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE conversations
+    SET last_message_at = NEW.created_at
+    WHERE id = NEW.conversation_id;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_last_message_trigger
+    AFTER INSERT ON messages
+    FOR EACH ROW
+    EXECUTE FUNCTION update_conversation_last_message();
+
+-- Function to auto-create future partitions (run monthly via cron)
+CREATE OR REPLACE FUNCTION create_messages_partition(partition_date DATE)
+RETURNS VOID AS $$
+DECLARE
+    partition_name TEXT;
+    start_date DATE;
+    end_date DATE;
+BEGIN
+    partition_name := 'messages_y' || to_char(partition_date, 'YYYY') || 'm' || to_char(partition_date, 'MM');
+    start_date := date_trunc('month', partition_date);
+    end_date := start_date + interval '1 month';
+
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF messages FOR VALUES FROM (%L) TO (%L)',
+        partition_name,
+        start_date,
+        end_date
+    );
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Add `conversations` table (direct, group, channel types)
- Add `conversation_participants` table
- Add `messages` table with **monthly partitioning** for high throughput
- Add `attachments` table for file uploads
- Add `message_reactions` table
- Add `read_receipts` table
- Add `pinned_messages` table
- Add auto-partition function for future months

## Schema (optimized for 500K msg/sec)
```
conversations
├── id (UUID, PK)
├── type (direct/group/channel)
├── name
├── creator_id
└── last_message_at

conversation_participants
├── conversation_id (FK)
├── user_id
├── role (owner/admin/member)
├── last_read_at
└── last_read_message_id

messages (PARTITIONED BY RANGE created_at)
├── id (UUID)
├── conversation_id
├── sender_id
├── type (text/image/file/audio/video/system)
├── content
├── metadata (JSONB)
├── reply_to_id
└── created_at

attachments, message_reactions, read_receipts, pinned_messages
```

## Performance features
- Monthly table partitioning for messages
- Optimized indexes for common queries
- Auto-partition creation function

## Test plan
- [ ] Run migrations: `make migrate-messaging`
- [ ] Verify partitions created for current months
- [ ] Test rollback: `make rollback-messaging`